### PR TITLE
Fixed example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ redisExpLock = require('redis-exp-lock');
 withLock = redisExpLock({redis: redis.createClient()});
 
 // Use the lock function to provide mutual exclusion.
-withLock(function(err, critSecDone) {
+withLock('lockName', function(err, critSecDone) {
   if (err) throw err;
   doStuffThatShouldNotBeInterrupted();
   critSecDone();


### PR DESCRIPTION
Example in README.md lists wrong code, which doesn't specify any lock key, though lock key argument is required.
