### PR TITLE
modified example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ The lock function takes two or three arguments:
 
 * A **Redis key** where the lock will be stored. This is most likely the name of the resource you are trying to lock.
 * An optional **settings object**, with overrides to the original lock configuration.
-* A **callback** that takes two arguments:
+* A **callback** that takes three arguments:
     * An **error** object. This is null if the lock attempt was successful.
+    * A **retries** count. Shows how many attempts were spent before the lock was succesfully acquired.
     * A **release function**, to be called in your application code after the critical section has completed. This will cause the lock to be released. Since the release function is itself asynchronous, you can pass it a callback that will be invoked when the release has been confirmed.
 
 ```js


### PR DESCRIPTION
Clarified arguments of critSecDone callback.

Currently README.md vaguely specifies that "Since the release function is itself asynchronous, you can pass it a callback that will be invoked when the release has been confirmed". This doesn't mentions that callback to the release function should be retrieved as a third argument, as the second is the retries count. Previously, this could be inferred only from the source code, in this pull request I've modified the example in README.md to show this explicitly.
